### PR TITLE
Hotfix/switchable dns cache

### DIFF
--- a/elasticsearch_async/connection.py
+++ b/elasticsearch_async/connection.py
@@ -12,7 +12,7 @@ from .helpers import ensure_future
 class AIOHttpConnection(Connection):
     def __init__(self, host='localhost', port=9200, http_auth=None,
             use_ssl=False, verify_certs=False, ca_certs=None, client_cert=None,
-            client_key=None, loop=None, **kwargs):
+            client_key=None, loop=None, use_dns_cache=True, **kwargs):
         super().__init__(host=host, port=port, **kwargs)
 
         self.loop = asyncio.get_event_loop() if loop is None else loop
@@ -30,7 +30,7 @@ class AIOHttpConnection(Connection):
                 loop=self.loop,
                 verify_ssl=verify_certs,
                 conn_timeout=self.timeout,
-
+                use_dns_cache=use_dns_cache,
             )
         )
 

--- a/test_elasticsearch_async/test_connection.py
+++ b/test_elasticsearch_async/test_connection.py
@@ -64,3 +64,13 @@ def test_timeout_is_properly_raised(connection, server):
 
     with raises(ConnectionTimeout):
         yield from connection.perform_request('GET', '/_search', timeout=0.0001)
+
+
+def test_dns_cache_is_enabled_by_default(event_loop):
+    connection = AIOHttpConnection(loop=event_loop)
+    assert connection.session.connector.use_dns_cache is True
+
+
+def test_dns_cache_can_be_disabled(event_loop):
+    connection = AIOHttpConnection(loop=event_loop, use_dns_cache=False)
+    assert connection.session.connector.use_dns_cache is False

--- a/test_elasticsearch_async/test_connection.py
+++ b/test_elasticsearch_async/test_connection.py
@@ -19,11 +19,11 @@ def test_info(connection):
     assert status == 200
     assert  {'body': '', 'method': 'GET', 'params': {}, 'path': '/'} == data
 
-def test_auth_is_set_correctly():
-    connection = AIOHttpConnection(http_auth=('user', 'secret'))
+def test_auth_is_set_correctly(event_loop):
+    connection = AIOHttpConnection(http_auth=('user', 'secret'), loop=event_loop)
     assert connection.session._default_auth == aiohttp.BasicAuth('user', 'secret')
 
-    connection = AIOHttpConnection(http_auth='user:secret')
+    connection = AIOHttpConnection(http_auth='user:secret', loop=event_loop)
     assert connection.session._default_auth == aiohttp.BasicAuth('user', 'secret')
 
 @mark.asyncio


### PR DESCRIPTION
As per #11, here's a PR with simple addition of `use_dns_cache` param to `AIOHttpConnection` / `aiohttp.TCPConnector` to allow disabling DNS cache.

Closes #11.