### PR TITLE
2.x release with DNS cache toggle option backported

### DIFF
--- a/elasticsearch_async/connection.py
+++ b/elasticsearch_async/connection.py
@@ -12,7 +12,7 @@ from .helpers import ensure_future
 class AIOHttpConnection(Connection):
     def __init__(self, host='localhost', port=9200, http_auth=None,
             use_ssl=False, verify_certs=False, ca_certs=None, client_cert=None,
-            client_key=None, loop=None, **kwargs):
+            client_key=None, loop=None, use_dns_cache=True, **kwargs):
         super().__init__(host=host, port=port, **kwargs)
 
         self.loop = asyncio.get_event_loop() if loop is None else loop
@@ -30,7 +30,7 @@ class AIOHttpConnection(Connection):
                 loop=self.loop,
                 verify_ssl=verify_certs,
                 conn_timeout=self.timeout,
-
+                use_dns_cache=use_dns_cache,
             )
         )
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from os.path import join, dirname
 from setuptools import setup, find_packages
 
-VERSION = (1, 0, 0)
+VERSION = (2, 0, 0)
 __version__ = VERSION
 __versionstr__ = '.'.join(map(str, VERSION))
 
@@ -12,7 +12,7 @@ f.close()
 
 install_requires = [
     'aiohttp',
-    'elasticsearch>=2.4.0',
+    'elasticsearch>=2.4.0,<3.0.0',
 ]
 
 tests_require = [

--- a/test_elasticsearch_async/test_connection.py
+++ b/test_elasticsearch_async/test_connection.py
@@ -64,3 +64,13 @@ def test_timeout_is_properly_raised(connection, server):
 
     with raises(ConnectionTimeout):
         yield from connection.perform_request('GET', '/_search', timeout=0.0001)
+
+
+def test_dns_cache_is_enabled_by_default(event_loop):
+    connection = AIOHttpConnection(loop=event_loop)
+    assert connection.session.connector.use_dns_cache is True
+
+
+def test_dns_cache_can_be_disabled(event_loop):
+    connection = AIOHttpConnection(loop=event_loop, use_dns_cache=False)
+    assert connection.session.connector.use_dns_cache is False

--- a/test_elasticsearch_async/test_connection.py
+++ b/test_elasticsearch_async/test_connection.py
@@ -19,11 +19,11 @@ def test_info(connection):
     assert status == 200
     assert  {'body': '', 'method': 'GET', 'params': {}, 'path': '/'} == data
 
-def test_auth_is_set_correctly():
-    connection = AIOHttpConnection(http_auth=('user', 'secret'))
+def test_auth_is_set_correctly(event_loop):
+    connection = AIOHttpConnection(http_auth=('user', 'secret'), loop=event_loop)
     assert connection.session._default_auth == aiohttp.BasicAuth('user', 'secret')
 
-    connection = AIOHttpConnection(http_auth='user:secret')
+    connection = AIOHttpConnection(http_auth='user:secret', loop=event_loop)
     assert connection.session._default_auth == aiohttp.BasicAuth('user', 'secret')
 
 @mark.asyncio


### PR DESCRIPTION
- Release of version `2.0.0`
- Backported  [Switchable DNS cache](https://github.com/elastic/elasticsearch-py-async/commit/95931b27e7f1a2b7946f562fd5421839e214f062)