### PR TITLE
Quick fix Issue #15 aiohttp version upper limit  < 2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ long_description = f.read().strip()
 f.close()
 
 install_requires = [
-    'aiohttp',
+    'aiohttp>1.3,<2.0.0',
     'elasticsearch>=5.0.0',
 ]
 


### PR DESCRIPTION
Set the upper limit for the aiohttp version to <2.0 and > 1.3 till elasticsearch_async is updated to be compatible with aiohttp 2.0