### PR TITLE
Fix DeprecationWarning: ClientSession.close() is a coroutine

### DIFF
--- a/elasticsearch_async/connection.py
+++ b/elasticsearch_async/connection.py
@@ -39,7 +39,7 @@ class AIOHttpConnection(Connection):
         )
 
     def close(self):
-        return self.session.close()
+        self.loop.run_until_complete(self.session.close())
 
     @asyncio.coroutine
     def perform_request(self, method, url, params=None, body=None, timeout=None, ignore=()):


### PR DESCRIPTION
Fix:

```
/usr/local/lib/python3.6/site-packages/aiohttp/helpers.py:139: DeprecationWarning: ClientSession.close() is a coroutine
  warnings.warn(self._msg, DeprecationWarning)
```