### PR TITLE
Fix for bulk() method failing on passing headers, and set default con…

### DIFF
--- a/elasticsearch_async/connection.py
+++ b/elasticsearch_async/connection.py
@@ -30,7 +30,8 @@ class AIOHttpConnection(Connection):
                 loop=self.loop,
                 verify_ssl=verify_certs,
                 use_dns_cache=use_dns_cache,
-            )
+            ),
+            headers={'content-type': 'application/json'}
         )
 
         self.base_url = 'http%s://%s:%d%s' % (
@@ -42,7 +43,7 @@ class AIOHttpConnection(Connection):
         return self.session.close()
 
     @asyncio.coroutine
-    def perform_request(self, method, url, params=None, body=None, timeout=None, ignore=()):
+    def perform_request(self, method, url, params=None, body=None, timeout=None, ignore=(), headers=None):
         url_path = url
         if params:
             url_path = '%s?%s' % (url, urlencode(params or {}))
@@ -52,7 +53,7 @@ class AIOHttpConnection(Connection):
         response = None
         try:
             with aiohttp.Timeout(timeout or self.timeout):
-                response = yield from self.session.request(method, url, data=body)
+                response = yield from self.session.request(method, url, data=body, headers=headers)
                 raw_data = yield from response.text()
             duration = self.loop.time() - start
 

--- a/elasticsearch_async/transport.py
+++ b/elasticsearch_async/transport.py
@@ -131,13 +131,13 @@ class AsyncTransport(Transport):
                 yield from c.close()
 
     @asyncio.coroutine
-    def main_loop(self, method, url, params, body, ignore=(), timeout=None):
+    def main_loop(self, method, url, params, body, headers=None, ignore=(), timeout=None):
         for attempt in range(self.max_retries + 1):
             connection = self.get_connection()
 
             try:
                 status, headers, data = yield from connection.perform_request(
-                        method, url, params, body, ignore=ignore, timeout=timeout)
+                        method, url, params, body, ignore=ignore, timeout=timeout, headers=headers)
             except TransportError as e:
                 if method == 'HEAD' and e.status_code == 404:
                     return False
@@ -169,7 +169,7 @@ class AsyncTransport(Transport):
                     data = self.deserializer.loads(data, headers.get('content-type'))
                 return data
 
-    def perform_request(self, method, url, params=None, body=None):
+    def perform_request(self, method, url, headers=None, params=None, body=None):
         if body is not None:
             body = self.serializer.dumps(body)
 
@@ -202,6 +202,7 @@ class AsyncTransport(Transport):
                 ignore = (ignore, )
 
         return ensure_future(self.main_loop(method, url, params, body,
+                                                    header=headers,
                                                     ignore=ignore,
                                                     timeout=timeout),
                              loop=self.loop)


### PR DESCRIPTION
…tent-type header

Ran into a couple of issues using this package with an ES6 cluster. bulk() operations were failing as the 'headers' keyword argument wasn't in the perform_request() method signature for the transport.

And with ES6 the Content-Type header is required, so I added a default "content-type: application/json" header to the session object, which I believe is how elasticsearch-py handles it too.