### PR TITLE
Add missing modules for SSL

### DIFF
--- a/elasticsearch_async/connection.py
+++ b/elasticsearch_async/connection.py
@@ -5,7 +5,7 @@ import warnings
 import aiohttp
 from aiohttp.client_exceptions import ServerFingerprintMismatch
 
-from elasticsearch.exceptions import ConnectionError, ConnectionTimeout, SSLError
+from elasticsearch.exceptions import ConnectionError, ConnectionTimeout, ImproperlyConfigured, SSLError
 from elasticsearch.connection import Connection
 from elasticsearch.compat import urlencode
 from elasticsearch.connection.http_urllib3 import create_ssl_context

--- a/elasticsearch_async/connection.py
+++ b/elasticsearch_async/connection.py
@@ -1,4 +1,6 @@
 import asyncio
+import ssl
+import warnings
 
 import aiohttp
 from aiohttp.client_exceptions import ServerFingerprintMismatch


### PR DESCRIPTION
The SSL logic in connection.py is missing imports for ssl and warnings.