### PR TITLE
Replace asyncio.Timeout with async_timeout.timeout

### DIFF
--- a/elasticsearch_async/connection.py
+++ b/elasticsearch_async/connection.py
@@ -2,6 +2,7 @@ import asyncio
 
 import aiohttp
 from aiohttp.client_exceptions import ServerFingerprintMismatch
+import async_timeout
 
 from elasticsearch.exceptions import ConnectionError, ConnectionTimeout, SSLError
 from elasticsearch.connection import Connection
@@ -90,7 +91,7 @@ class AIOHttpConnection(Connection):
         start = self.loop.time()
         response = None
         try:
-            with aiohttp.Timeout(timeout or self.timeout, loop=self.loop):
+            with async_timeout.timeout(timeout or self.timeout, loop=self.loop):
                 response = yield from self.session.request(method, url, data=body, headers=headers)
                 raw_data = yield from response.text()
             duration = self.loop.time() - start

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ f.close()
 
 install_requires = [
     'aiohttp',
+    'async_timeout',
     'elasticsearch>=6.0.0',
 ]
 


### PR DESCRIPTION
Aiohttp 3.0 drops `aiohttp.Timeout` (which had been just an alias of `async_timeout.timeout`), so we now should/have to use `async_timeout.timeout` directly.

closes #37