### PR TITLE
asyncio.CancelledError shouldn't be logged as a request failure

### DIFF
--- a/elasticsearch_async/connection.py
+++ b/elasticsearch_async/connection.py
@@ -99,6 +99,9 @@ class AIOHttpConnection(Connection):
                 raw_data = yield from response.text()
             duration = self.loop.time() - start
 
+        except asyncio.CancelledError:
+            raise
+
         except Exception as e:
             self.log_request_fail(method, url, url_path, body, self.loop.time() - start, exception=e)
             if isinstance(e, ServerFingerprintMismatch):

--- a/elasticsearch_async/connection_pool.py
+++ b/elasticsearch_async/connection_pool.py
@@ -9,8 +9,8 @@ class AsyncConnectionPool(ConnectionPool):
         super().__init__(connections, **kwargs)
 
     async def close(self):
-        await asyncio.gather(*[conn.close() for conn in self.orig_connections],
-                             loop=self.loop)
+        await asyncio.wait([conn.close() for conn in self.orig_connections],
+                           loop=self.loop)
 
 
 class AsyncDummyConnectionPool(DummyConnectionPool):


### PR DESCRIPTION
`asyncio.CancelledError` is not a real error and it shouldn't be logged as a request failure.

For example, webapp's request handling tasks will be cancelled with `CancelledError` when clients abort their requests.