### PR TITLE
#5 async heplers: scan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: python
+
+jdk:
+  oraclejdk9
+
+python:
+  - 3.5
+  - 3.6
+  - 3.7-dev
+
+env:
+  - ES_VERSION=6.4.3
+
+before_install:
+  - docker run -d -p 9200:9200 -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch-oss:$ES_VERSION
+
+install:
+  - pip install .[develop]
+
+script:
+  - pytest

--- a/elasticsearch_async/__init__.py
+++ b/elasticsearch_async/__init__.py
@@ -3,6 +3,7 @@ from .connection import AIOHttpConnection
 
 from elasticsearch import Elasticsearch
 
+
 class AsyncElasticsearch(Elasticsearch):
     def __init__(self, hosts=None, transport_class=AsyncTransport, **kwargs):
         super().__init__(hosts, transport_class=transport_class, **kwargs)

--- a/elasticsearch_async/helpers.py
+++ b/elasticsearch_async/helpers.py
@@ -34,12 +34,16 @@ class _Scan:
                 maintained for scrolled search
             raise_on_error (bool): if to raise ``ScanError`` when some shards fail.
                 ``True`` by default
-            preserve_order (): don't set the ``search_type`` to ``scan`` — this will
-                cause the scroll to paginate with preserving the order. Note that this
-                can be an extremely expensive operation and can easily lead to
-                unpredictable results, use with caution  # TODO: type? human-readable doc?
+            preserve_order (bool): if to preserve sorting from query.
+                If set to ``False``, documents will be sorted by ``doc`` —
+                this leverages internal optimization for faster scrolling.
+                Setting this to ``True`` may be extremely expensive.
+                ``False`` by default
             size (int): Batch size (per shard) for every iteration
-            request_timeout (): explicit timeout for each call to ``scan``  # TODO: type?
+            request_timeout (str): explicit timeout for each call to ``scan``.
+              Must correspond ``Time units`` format, look to
+              https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html#time-units
+              for details
             clear_scroll (bool): if to delete scroll state in ES after getting
                 error or consuming all results. Default is ``True``
             scroll_kwargs (dict): additional kwargs to be passed to

--- a/elasticsearch_async/helpers.py
+++ b/elasticsearch_async/helpers.py
@@ -4,7 +4,6 @@ from collections import deque
 
 from elasticsearch.helpers import ScanError
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -20,12 +19,8 @@ class _Scan:
         Simple abstraction on top of the
         :meth:`~elasticsearch_async.AsyncElasticsearch.scroll` api - a simple
         iterator that yields all hits as returned by underlining scroll requests.
-
-        By default scan does not return results in any pre-determined order. To
-        have a standard order in the returned documents (either by score or
-        explicit sort definition) when scrolling, use ``preserve_order=True``. This
-        may be an expensive operation and will negate the performance benefits of
-        using ``scan``
+        For the sake of naming compatibility with sync library, public interface
+        is ``elasticsearch_async.helpers.scan``
 
         Args:
             client (elasticsearch_async.AsyncElasticsearch): async client to use
@@ -37,8 +32,8 @@ class _Scan:
             preserve_order (bool): if to preserve sorting from query.
                 If set to ``False``, documents will be sorted by ``doc`` —
                 this leverages internal optimization for faster scrolling.
-                Setting this to ``True`` may be extremely expensive.
-                ``False`` by default
+                Setting this to ``True`` may be extremely expensive and negate
+                benefits of scrolling. ``False`` by default
             size (int): Batch size (per shard) for every iteration
             request_timeout (str): explicit timeout for each call to ``scan``.
               Must correspond ``Time units`` format, look to
@@ -55,7 +50,21 @@ class _Scan:
             ScanError: raised when ``raise_on_error is True`` and any shard fails
 
         Examples:
-            # TODO
+            Scan over all documents::
+                aes = AsyncElasticsearch()
+                async for doc in scan(aes): ...
+
+            Get all documents from ``async`` index::
+                async_docs = [d async for d in scan(aes, index='async')]
+
+            Filter documents by ``topic`` term::
+                async_gen = scan(
+                    aes,
+                    query={'query': {'term': {'topic': 'async'}}})
+                async_docs = [d async for d in async_gen]
+
+            Get all documents, fetch documents 100 at time, ignore failures::
+                async for d in scan(aes, size=100, raise_on_error=False): ...
         """
         self.client = client
         self.query = query or {}

--- a/elasticsearch_async/helpers.py
+++ b/elasticsearch_async/helpers.py
@@ -1,4 +1,125 @@
 import asyncio
+import logging
+from collections import deque
+
+from elasticsearch.helpers import ScanError
+
+
+logger = logging.getLogger(__name__)
+
 
 ensure_future = (getattr(asyncio, 'ensure_future', None) or
                  getattr(asyncio, 'async', None))
+
+
+class Scan:
+    def __init__(self, client, query=None, scroll='5m', raise_on_error=True,
+                 preserve_order=False, size=1000, request_timeout=None,
+                 clear_scroll=True, scroll_kwargs=None, **kwargs):
+        """
+        Simple abstraction on top of the
+        :meth:`~elasticsearch_async.AsyncElasticsearch.scroll` api - a simple
+        iterator that yields all hits as returned by underlining scroll requests.
+
+        By default scan does not return results in any pre-determined order. To
+        have a standard order in the returned documents (either by score or
+        explicit sort definition) when scrolling, use ``preserve_order=True``. This
+        may be an expensive operation and will negate the performance benefits of
+        using ``scan``
+
+        Args:
+            client (elasticsearch_async.AsyncElasticsearch): async client to use
+            query (dict): query body, same as for regular search
+            scroll (str): Specify how long a consistent view of the index should be
+                maintained for scrolled search
+            raise_on_error (bool): if to raise ``ScanError`` when some shards fail.
+                ``True`` by default
+            preserve_order (): don't set the ``search_type`` to ``scan`` — this will
+                cause the scroll to paginate with preserving the order. Note that this
+                can be an extremely expensive operation and can easily lead to
+                unpredictable results, use with caution  # TODO: type? human-readable doc?
+            size (int): Batch size (per shard) for every iteration
+            request_timeout (): explicit timeout for each call to ``scan``  # TODO: type?
+            clear_scroll (bool): if to delete scroll state in ES after getting
+                error or consuming all results. Default is ``True``
+            scroll_kwargs (dict): additional kwargs to be passed to
+                :meth:`~elasticsearch.Elasticsearch.scroll`
+            **kwargs: Any additional keyword arguments will be passed to the initial
+                :meth:`~elasticsearch.Elasticsearch.search` call
+
+        Raises:
+            ScanError: raised when ``raise_on_error is True`` and any shard fails
+
+        Examples:
+            # TODO
+        """
+        self.client = client
+        self.query = query or {}
+        if not preserve_order:
+            self.query = self.query.copy()
+            self.query["sort"] = "_doc"
+        self.scroll = scroll
+        self.raise_on_error = raise_on_error
+        self.size = size
+        self.request_timeout = request_timeout
+        self.clear_scroll = clear_scroll
+        self.scroll_kwargs = scroll_kwargs or {}
+        self.kwargs = kwargs
+
+        self._hits = deque()
+        self._scroll_id = None
+
+    def __aiter__(self):
+        return self
+
+    async def _clear(self):
+        if self._scroll_id and self.clear_scroll:
+            await self.client.clear_scroll(
+                body={'scroll_id': [self._scroll_id]},
+                ignore=(404,))
+
+    async def __anext__(self):
+        if not self._hits:
+            try:
+                await self._fetch()
+            except ScanError:
+                await self._clear()
+                raise
+
+        try:
+            return self._hits.popleft()
+        except IndexError:
+            await self._clear()
+            raise StopAsyncIteration
+
+    async def _fetch(self):
+        if self._scroll_id is None:
+            resp = await self.client.search(
+                body=self.query,
+                scroll=self.scroll,
+                size=self.size,
+                request_timeout=self.request_timeout,
+                **self.kwargs)
+        else:
+            resp = await self.client.scroll(
+                self._scroll_id,
+                scroll=self.scroll,
+                request_timeout=self.request_timeout,
+                **self.scroll_kwargs)
+
+        self._scroll_id = resp.get('_scroll_id')
+
+        if resp['_shards']['successful'] < resp['_shards']['total']:
+            logger.warning(
+                'Scroll request has only succeeded on %d shards out of %d.',
+                resp['_shards']['successful'], resp['_shards']['total'])
+            if self.raise_on_error:
+                raise ScanError(
+                    self._scroll_id,
+                    'Scroll request has only succeeded on %d shards out of %d.' %
+                    (resp['_shards']['successful'], resp['_shards']['total']))
+
+        self._hits.extend(resp['hits']['hits'])
+
+
+scan = Scan

--- a/elasticsearch_async/helpers.py
+++ b/elasticsearch_async/helpers.py
@@ -12,7 +12,7 @@ ensure_future = (getattr(asyncio, 'ensure_future', None) or
                  getattr(asyncio, 'async', None))
 
 
-class Scan:
+class _Scan:
     def __init__(self, client, query=None, scroll='5m', raise_on_error=True,
                  preserve_order=False, size=1000, request_timeout=None,
                  clear_scroll=True, scroll_kwargs=None, **kwargs):
@@ -122,4 +122,4 @@ class Scan:
         self._hits.extend(resp['hits']['hits'])
 
 
-scan = Scan
+scan = _Scan

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ tests_require = [
     'pytest',
     'pytest-asyncio',
     'pytest-cov',
+    'pytest-mock',
 ]
 
 setup(

--- a/test_elasticsearch_async/__init__.py
+++ b/test_elasticsearch_async/__init__.py
@@ -1,0 +1,8 @@
+import sys
+
+import pytest
+
+
+def required_python(major, minor):
+    return pytest.mark.skipif(sys.version_info < (major, minor),
+                              reason='Python {}.{} or higher is required'.format(major, minor))

--- a/test_elasticsearch_async/conftest.py
+++ b/test_elasticsearch_async/conftest.py
@@ -100,3 +100,11 @@ def sniff_data():
             }
         }
     }
+
+
+@fixture
+async def es():
+    es = AsyncElasticsearch()
+    await es.indices.delete('test_*', ignore=404)
+    yield es
+    await es.transport.close()

--- a/test_elasticsearch_async/test_helpers/test_scan.py
+++ b/test_elasticsearch_async/test_helpers/test_scan.py
@@ -1,0 +1,99 @@
+from json import dumps
+
+import pytest
+from elasticsearch.helpers import ScanError
+
+from elasticsearch_async.helpers import scan
+from test_elasticsearch_async import required_python
+
+pytestmark = [
+    pytest.mark.asyncio,
+    required_python(3, 5)
+]
+
+
+@pytest.fixture(autouse=True)
+async def es_data(es):
+    actions = [
+        {'index': {'_id': 1}}, {'field': 'a'},
+        {'index': {'_id': 2}}, {'field': 'b'},
+        {'index': {'_id': 3}}, {'field': 'c'},
+        {'index': {'_id': 4}}, {'field': 'd'},
+        {'index': {'_id': 5}}, {'field': 'e'},
+        {'index': {'_id': 6}}, {'field': 'f'},
+        {'index': {'_id': 7}}, {'field': 'g'},
+        {'index': {'_id': 8}}, {'field': 'h'},
+    ]
+    await es.bulk(
+        body='\n'.join(dumps(row) for row in actions),
+        index='test_scan',
+        doc_type='doc',
+        refresh=True,
+    )
+
+
+async def test_basic(es, mocker):
+    mocker.spy(es.transport, 'perform_request')
+
+    docs = [d async for d in scan(es, size=5)]
+    assert len(docs) == 8
+    assert {d['_id'] for d in docs} == set(map(str, range(1, 9)))
+    assert {d['_source']['field'] for d in docs} == set('abcdefgh')
+
+    assert es.transport.perform_request.call_args_list == [
+        (('GET', '/_search'), mocker.ANY),            # initial search
+        (('GET', '/_search/scroll'), mocker.ANY),     # scan
+        (('GET', '/_search/scroll'), mocker.ANY),     # empty scan
+        (('DELETE', '/_search/scroll'), mocker.ANY),  # scroll cleanup
+    ]
+
+
+async def _active_scrolls(es):
+    raw = await es.cat.nodes(h='search.scroll_current')
+    return int(raw.strip('\n'))
+
+
+async def test_cleanup(es):
+    assert await _active_scrolls(es) == 0
+
+    _ = [d async for d in scan(es, clear_scroll=True)]
+    assert await _active_scrolls(es) == 0
+
+    generator = scan(es, clear_scroll=False)
+    _ = [d async for d in generator]
+    assert await _active_scrolls(es) != 0
+
+    await es.clear_scroll(scroll_id=generator._scroll_id)
+
+
+async def test_scan_error(es, mocker):
+    def failing_shard(func):
+        async def wrapper(*args, **kwargs):
+            response = await func(*args, **kwargs)
+            if '_shards' in response:
+                response['_shards']['successful'] -= 1
+                response['_shards']['failed'] += 1
+            return response
+        return wrapper
+
+    res = [d async for d in scan(es)]
+    assert len(res) == 8
+
+    warning_mock = mocker.patch('elasticsearch_async.helpers.logger.warning')
+    mock_request = mocker.patch.object(
+        es.transport,
+        'perform_request',
+        wraps=failing_shard(es.transport.perform_request)
+    )
+
+    with pytest.raises(ScanError):
+        _ = [d async for d in scan(es)]
+    assert warning_mock.called
+    assert await _active_scrolls(es) == 0
+
+    mocker.resetall()
+    res = [d async for d in scan(es, raise_on_error=False)]
+    assert len(res) == 8
+    assert warning_mock.called
+    assert await _active_scrolls(es) == 0
+

--- a/test_elasticsearch_async/test_helpers/test_scan.py
+++ b/test_elasticsearch_async/test_helpers/test_scan.py
@@ -80,7 +80,7 @@ async def test_scan_error(es, mocker):
     assert len(res) == 8
 
     warning_mock = mocker.patch('elasticsearch_async.helpers.logger.warning')
-    mock_request = mocker.patch.object(
+    mocker.patch.object(
         es.transport,
         'perform_request',
         wraps=failing_shard(es.transport.perform_request)


### PR DESCRIPTION
Feel free to drop in any criticism or proposals.

Limitations of current implementation is to be able to use this in 3.5 (afaik, this was the point of @HonzaKral some time ago). Therefore two major problems so far:
 - no way to keep this simple as `while hits: yield`, need to support low-level aiter interface. There's 3rd-party libs (from trio, I believe) that makes life a bit easier, but I'm kind of sceptical on adding such dep
 - I don't know [better] way to reliably close scroll context with `finally` with 3.5 syntax

Work on streaming writes/reindex will be done in separate PR, this is overcrowded already.