### PR TITLE
Backport of ES6 commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ dist
 build
 *.egg
 coverage.xml
+.pytest_cache
 junit.xml
 test_elasticsearch_async/htmlcov
 docs/_build

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,13 @@
+include AUTHORS
+include Changelog.rst
+include CONTRIBUTING.md
+include LICENSE
+include MANIFEST.in
+include README.rst
+include README
+include setup.py
+recursive-include docs *
+ prune docs/_build
+prune test_elasticsearch_async
+recursive-exclude * __pycache__
+recursive-exclude * *.py[co]

--- a/elasticsearch_async/connection.py
+++ b/elasticsearch_async/connection.py
@@ -49,9 +49,8 @@ class AIOHttpConnection(Connection):
     def close(self):
         yield from self.session.close()
 
-    @asyncio.coroutine
-    def perform_request(self, method, url, params=None, body=None,
-                        timeout=None, ignore=(), headers=None):
+    async def perform_request(self, method, url, params=None, body=None,
+                              timeout=None, ignore=(), headers=None):
         url_path = url
         if params:
             url_path = '%s?%s' % (url, urlencode(params or {}))
@@ -60,12 +59,12 @@ class AIOHttpConnection(Connection):
         start = self.loop.time()
         response = None
         try:
-            with async_timeout.timeout(timeout or self.timeout,
-                                       loop=self.loop):
-                response = yield from self.session.request(
+            async with async_timeout.timeout(timeout or self.timeout,
+                                             loop=self.loop):
+                response = await self.session.request(
                     method, url, data=body, headers=headers
                 )
-                raw_data = yield from response.text()
+                raw_data = await response.text()
             duration = self.loop.time() - start
 
         except asyncio.CancelledError:
@@ -82,7 +81,7 @@ class AIOHttpConnection(Connection):
 
         finally:
             if response is not None:
-                yield from response.release()
+                await response.release()
 
         # raise errors based on http status codes,
         # let the client handle those if needed

--- a/elasticsearch_async/connection_pool.py
+++ b/elasticsearch_async/connection_pool.py
@@ -1,0 +1,19 @@
+import asyncio
+
+from elasticsearch import ConnectionPool
+from elasticsearch.connection_pool import DummyConnectionPool
+
+
+class AsyncConnectionPool(ConnectionPool):
+    def __init__(self, connections, loop, **kwargs):
+        self.loop = loop
+        super().__init__(connections, **kwargs)
+
+    async def close(self):
+        await asyncio.wait([conn.close() for conn in self.orig_connections],
+                           loop=self.loop)
+
+
+class AsyncDummyConnectionPool(DummyConnectionPool):
+    async def close(self):
+        await self.connection.close()

--- a/elasticsearch_async/helpers.py
+++ b/elasticsearch_async/helpers.py
@@ -1,3 +1,4 @@
 import asyncio
 
-ensure_future = getattr(asyncio, 'ensure_future', asyncio.async)
+ensure_future = (getattr(asyncio, 'ensure_future', None) or
+                 getattr(asyncio, 'async', None))

--- a/elasticsearch_async/transport.py
+++ b/elasticsearch_async/transport.py
@@ -4,19 +4,26 @@ import logging
 from itertools import chain
 
 from elasticsearch import Transport, TransportError, ConnectionTimeout, ConnectionError, SerializationError
+from elasticsearch.connection_pool import DummyConnectionPool
 
+from .connection_pool import AsyncConnectionPool, AsyncDummyConnectionPool
 from .connection import AIOHttpConnection
 from .helpers import ensure_future
 
+
 logger = logging.getLogger('elasticsearch')
+
 
 class AsyncTransport(Transport):
     def __init__(self, hosts, connection_class=AIOHttpConnection, loop=None,
+                 connection_pool_class=AsyncConnectionPool,
                  sniff_on_start=False, raise_on_sniff_error=True, **kwargs):
         self.raise_on_sniff_error = raise_on_sniff_error
         self.loop = asyncio.get_event_loop() if loop is None else loop
         kwargs['loop'] = self.loop
-        super().__init__(hosts, connection_class=connection_class, sniff_on_start=False, **kwargs)
+        super().__init__(hosts, connection_class=connection_class,
+                         sniff_on_start=False,
+                         connection_pool_class=connection_pool_class, **kwargs)
 
         self.sniffing_task = None
         if sniff_on_start:
@@ -40,12 +47,20 @@ class AsyncTransport(Transport):
                 self.sniffing_task = None
 
         if self.sniffing_task is None:
-            self.sniffing_task = ensure_future(self.sniff_hosts(initial), loop=self.loop)
+            self.sniffing_task = ensure_future(self.sniff_hosts(initial),
+                                               loop=self.loop)
 
+    @asyncio.coroutine
     def close(self):
         if self.sniffing_task:
             self.sniffing_task.cancel()
-        super().close()
+        yield from self.connection_pool.close()
+
+    def set_connections(self, hosts):
+        super().set_connections(hosts)
+        if isinstance(self.connection_pool, DummyConnectionPool):
+            self.connection_pool = AsyncDummyConnectionPool(
+                self.connection_pool.connection_opts)
 
     def get_connection(self):
         if self.sniffer_timeout:
@@ -72,19 +87,23 @@ class AsyncTransport(Transport):
             c.perform_request('GET', '/_nodes/_all/http', timeout=timeout)
             # go through all current connections as well as the
             # seed_connections for good measure
-            for c in chain(self.connection_pool.connections, (c for c in self.seed_connections if c not in self.connection_pool.connections))
+            for c in chain(self.connection_pool.connections,
+                           (c for c in self.seed_connections
+                            if c not in self.connection_pool.connections))
         ]
 
         done = ()
         try:
             while tasks:
                 # execute sniff requests in parallel, wait for first to return
-                done, tasks = yield from asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED, loop=self.loop)
+                done, tasks = yield from asyncio.wait(
+                    tasks, return_when=asyncio.FIRST_COMPLETED, loop=self.loop)
                 # go through all the finished tasks
                 for t in done:
                     try:
                         _, headers, node_info = t.result()
-                        node_info = self.deserializer.loads(node_info, headers.get('content-type'))
+                        node_info = self.deserializer.loads(
+                            node_info, headers.get('content-type'))
                     except (ConnectionError, SerializationError) as e:
                         logger.warn('Sniffing request failed with %r', e)
                         continue
@@ -108,7 +127,8 @@ class AsyncTransport(Transport):
         Obtain a list of nodes from the cluster and create a new connection
         pool using the information retrieved.
 
-        To extract the node connection parameters use the ``nodes_to_host_callback``.
+        To extract the node connection parameters use the
+        ``nodes_to_host_callback``.
 
         :arg initial: flag indicating if this is during startup
             (``sniff_on_start``), ignore the ``sniff_timeout`` if ``True``
@@ -120,7 +140,8 @@ class AsyncTransport(Transport):
         # we weren't able to get any nodes, maybe using an incompatible
         # transport_schema or host_info_callback blocked all - raise error.
         if not hosts:
-            raise TransportError("N/A", "Unable to sniff hosts - no viable hosts found.")
+            raise TransportError(
+                "N/A", "Unable to sniff hosts - no viable hosts found.")
 
         # remember current live connections
         orig_connections = self.connection_pool.connections[:]
@@ -131,13 +152,16 @@ class AsyncTransport(Transport):
                 yield from c.close()
 
     @asyncio.coroutine
-    def main_loop(self, method, url, params, body, ignore=(), timeout=None):
+    def main_loop(self, method, url, params, body, headers=None, ignore=(),
+                  timeout=None):
         for attempt in range(self.max_retries + 1):
             connection = self.get_connection()
 
             try:
                 status, headers, data = yield from connection.perform_request(
-                        method, url, params, body, ignore=ignore, timeout=timeout)
+                    method, url, params, body, headers=headers, ignore=ignore,
+                    timeout=timeout
+                )
             except TransportError as e:
                 if method == 'HEAD' and e.status_code == 404:
                     return False
@@ -166,10 +190,12 @@ class AsyncTransport(Transport):
                 # connection didn't fail, confirm it's live status
                 self.connection_pool.mark_live(connection)
                 if data:
-                    data = self.deserializer.loads(data, headers.get('content-type'))
+                    data = self.deserializer.loads(data,
+                                                   headers.get('content-type'))
                 return data
 
-    def perform_request(self, method, url, params=None, body=None):
+    def perform_request(self, method, url, headers=None, params=None,
+                        body=None):
         if body is not None:
             body = self.serializer.dumps(body)
 
@@ -202,7 +228,8 @@ class AsyncTransport(Transport):
                 ignore = (ignore, )
 
         return ensure_future(self.main_loop(method, url, params, body,
-                                                    ignore=ignore,
-                                                    timeout=timeout),
+                                            headers=headers,
+                                            ignore=ignore,
+                                            timeout=timeout),
                              loop=self.loop)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[wheel]
-universal = 1

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ f.close()
 
 install_requires = [
     'aiohttp>=3.0.0',
-    'async_timeout>=2.0',
+    'async_timeout',
     'elasticsearch>=5.0.0, <6.0.0',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -11,15 +11,15 @@ long_description = f.read().strip()
 f.close()
 
 install_requires = [
-    'aiohttp',
-    'elasticsearch>=5.0.0',
+    'aiohttp>=3.0.0',
+    'async_timeout>=2.0',
+    'elasticsearch>=5.0.0, <6.0.0',
 ]
 
 tests_require = [
     'pytest',
     'pytest-asyncio',
     'pytest-cov',
-    'pytest-catchlog',
 ]
 
 setup(
@@ -41,12 +41,14 @@ setup(
         "Intended Audience :: Developers",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: Implementation :: CPython",
     ],
     install_requires=install_requires,
+    python_requires="~=3.5",
 
     test_suite="test_elasticsearch_async.run_tests.run_all",
     tests_require=tests_require,

--- a/test_elasticsearch_async/conftest.py
+++ b/test_elasticsearch_async/conftest.py
@@ -61,6 +61,7 @@ def port():
     i += 1
     return 8080 + i
 
+
 @yield_fixture
 def server(event_loop, port):
     server = DummyElasticsearch(debug=True, loop=event_loop)

--- a/test_elasticsearch_async/run_tests.py
+++ b/test_elasticsearch_async/run_tests.py
@@ -3,6 +3,7 @@ import sys
 
 import pytest
 
+
 def run_all(argv=None):
     # always insert coverage when running tests through setup.py
     if argv is None:
@@ -11,6 +12,7 @@ def run_all(argv=None):
         argv = argv[1:]
 
     sys.exit(pytest.main(argv))
+
 
 if __name__ == '__main__':
     run_all(sys.argv)

--- a/test_elasticsearch_async/test_client.py
+++ b/test_elasticsearch_async/test_client.py
@@ -8,14 +8,16 @@ def test_custom_body(server, client):
     data = yield from client.info()
 
     assert [('GET', '/', '', {})] == server.calls
-    assert  {'custom': 'body'} == data
+    assert {'custom': 'body'} == data
+
 
 @mark.asyncio
 def test_info_works(server, client):
     data = yield from client.info()
 
     assert [('GET', '/', '', {})] == server.calls
-    assert  {'body': '', 'method': 'GET', 'params': {}, 'path': '/'} == data
+    assert {'body': '', 'method': 'GET', 'params': {}, 'path': '/'} == data
+
 
 @mark.asyncio
 def test_ping_works(server, client):
@@ -24,6 +26,7 @@ def test_ping_works(server, client):
     assert [('HEAD', '/', '', {})] == server.calls
     assert data is True
 
+
 @mark.asyncio
 def test_exists_with_404_returns_false(server, client):
     server.register_response('/not-there', status=404)
@@ -31,18 +34,21 @@ def test_exists_with_404_returns_false(server, client):
 
     assert data is False
 
+
 @mark.asyncio
 def test_404_properly_raised(server, client):
     server.register_response('/i/t/42', status=404)
     with raises(NotFoundError):
         yield from client.get(index='i', doc_type='t', id=42)
 
+
 @mark.asyncio
 def test_body_gets_passed_properly(client):
     data = yield from client.index(index='i', doc_type='t', id='42', body={'some': 'data'})
-    assert  {'body': {'some': 'data'}, 'method': 'PUT', 'params': {}, 'path': '/i/t/42'} == data
+    assert {'body': {'some': 'data'}, 'method': 'PUT', 'params': {}, 'path': '/i/t/42'} == data
+
 
 @mark.asyncio
 def test_params_get_passed_properly(client):
     data = yield from client.info(params={'some': 'data'})
-    assert  {'body': '', 'method': 'GET', 'params': {'some': 'data'}, 'path': '/'} == data
+    assert {'body': '', 'method': 'GET', 'params': {'some': 'data'}, 'path': '/'} == data

--- a/test_elasticsearch_async/test_client.py
+++ b/test_elasticsearch_async/test_client.py
@@ -2,53 +2,57 @@ from pytest import mark, raises
 
 from elasticsearch import NotFoundError
 
+
 @mark.asyncio
-def test_custom_body(server, client):
+async def test_custom_body(server, client):
     server.register_response('/', {'custom': 'body'})
-    data = yield from client.info()
+    data = await client.info()
 
     assert [('GET', '/', '', {})] == server.calls
     assert {'custom': 'body'} == data
 
 
 @mark.asyncio
-def test_info_works(server, client):
-    data = yield from client.info()
+async def test_info_works(server, client):
+    data = await client.info()
 
     assert [('GET', '/', '', {})] == server.calls
     assert {'body': '', 'method': 'GET', 'params': {}, 'path': '/'} == data
 
 
 @mark.asyncio
-def test_ping_works(server, client):
-    data = yield from client.ping()
+async def test_ping_works(server, client):
+    data = await client.ping()
 
     assert [('HEAD', '/', '', {})] == server.calls
     assert data is True
 
 
 @mark.asyncio
-def test_exists_with_404_returns_false(server, client):
+async def test_exists_with_404_returns_false(server, client):
     server.register_response('/not-there', status=404)
-    data = yield from client.indices.exists(index='not-there')
+    data = await client.indices.exists(index='not-there')
 
     assert data is False
 
 
 @mark.asyncio
-def test_404_properly_raised(server, client):
+async def test_404_properly_raised(server, client):
     server.register_response('/i/t/42', status=404)
     with raises(NotFoundError):
-        yield from client.get(index='i', doc_type='t', id=42)
+        await client.get(index='i', doc_type='t', id=42)
 
 
 @mark.asyncio
-def test_body_gets_passed_properly(client):
-    data = yield from client.index(index='i', doc_type='t', id='42', body={'some': 'data'})
-    assert {'body': {'some': 'data'}, 'method': 'PUT', 'params': {}, 'path': '/i/t/42'} == data
+async def test_body_gets_passed_properly(client):
+    data = await client.index(index='i', doc_type='t', id='42',
+                              body={'some': 'data'})
+    assert {'body': {'some': 'data'}, 'method': 'PUT', 'params': {},
+            'path': '/i/t/42'} == data
 
 
 @mark.asyncio
-def test_params_get_passed_properly(client):
-    data = yield from client.info(params={'some': 'data'})
-    assert {'body': '', 'method': 'GET', 'params': {'some': 'data'}, 'path': '/'} == data
+async def test_params_get_passed_properly(client):
+    data = await client.info(params={'some': 'data'})
+    assert {'body': '', 'method': 'GET', 'params': {'some': 'data'},
+            'path': '/'} == data

--- a/test_elasticsearch_async/test_connection.py
+++ b/test_elasticsearch_async/test_connection.py
@@ -4,11 +4,12 @@ import logging
 
 import aiohttp
 
-from pytest import mark, yield_fixture, raises
+from pytest import mark, raises
 
 from elasticsearch import NotFoundError, ConnectionTimeout
 
 from elasticsearch_async.connection import AIOHttpConnection
+
 
 @mark.asyncio
 def test_info(connection):
@@ -19,40 +20,53 @@ def test_info(connection):
     assert status == 200
     assert  {'body': '', 'method': 'GET', 'params': {}, 'path': '/'} == data
 
+
 def test_auth_is_set_correctly(event_loop):
-    connection = AIOHttpConnection(http_auth=('user', 'secret'), loop=event_loop)
-    assert connection.session._default_auth == aiohttp.BasicAuth('user', 'secret')
+    connection = AIOHttpConnection(http_auth=('user', 'secret'),
+                                   loop=event_loop)
+    assert connection.session._default_auth == aiohttp.BasicAuth('user',
+                                                                 'secret')
 
     connection = AIOHttpConnection(http_auth='user:secret', loop=event_loop)
-    assert connection.session._default_auth == aiohttp.BasicAuth('user', 'secret')
+    assert connection.session._default_auth == aiohttp.BasicAuth('user',
+                                                                 'secret')
+
 
 @mark.asyncio
 def test_request_is_properly_logged(connection, caplog, port, server):
     server.register_response('/_cat/indices', {'cat': 'indices'})
-    yield from connection.perform_request('GET', '/_cat/indices', body=b'{}', params={"format": "json"})
+    yield from connection.perform_request('GET', '/_cat/indices', body=b'{}',
+                                          params={"format": "json"})
 
     for logger, level, message in caplog.record_tuples:
         if logger == 'elasticsearch' and level == logging.INFO:
-            assert message.startswith('GET http://localhost:%s/_cat/indices?format=json [status:200 request:' % port)
+            assert \
+                message.startswith('GET http://localhost:%s/_cat/indices?'
+                                   'format=json [status:200 request:' % port)
             break
     else:
         assert False, 'Message not found'
 
     assert ('elasticsearch', logging.DEBUG, '> {}') in caplog.record_tuples
-    assert ('elasticsearch', logging.DEBUG, '< {"cat": "indices"}') in caplog.record_tuples
+    assert ('elasticsearch', logging.DEBUG, '< {"cat": "indices"}') \
+        in caplog.record_tuples
+
 
 @mark.asyncio
 def test_error_is_properly_logged(connection, caplog, port, server):
     server.register_response('/i', status=404)
     with raises(NotFoundError):
-        yield from connection.perform_request('GET', '/i', params={'some': 'data'})
+        yield from connection.perform_request('GET', '/i',
+                                              params={'some': 'data'})
 
     for logger, level, message in caplog.record_tuples:
         if logger == 'elasticsearch' and level == logging.WARNING:
-            assert message.startswith('GET http://localhost:%s/i?some=data [status:404 request:' % port)
+            assert message.startswith('GET http://localhost:%s/i?'
+                                      'some=data [status:404 request:' % port)
             break
     else:
         assert False, "Log not received"
+
 
 @mark.asyncio
 def test_timeout_is_properly_raised(connection, server):
@@ -63,7 +77,8 @@ def test_timeout_is_properly_raised(connection, server):
     server.register_response('/_search', slow_request())
 
     with raises(ConnectionTimeout):
-        yield from connection.perform_request('GET', '/_search', timeout=0.0001)
+        yield from connection.perform_request('GET', '/_search',
+                                              timeout=0.0001)
 
 
 def test_dns_cache_is_enabled_by_default(event_loop):

--- a/test_elasticsearch_async/test_connection.py
+++ b/test_elasticsearch_async/test_connection.py
@@ -12,13 +12,13 @@ from elasticsearch_async.connection import AIOHttpConnection
 
 
 @mark.asyncio
-def test_info(connection):
-    status, headers, data = yield from connection.perform_request('GET', '/')
+async def test_info(connection):
+    status, headers, data = await connection.perform_request('GET', '/')
 
     data = json.loads(data)
 
     assert status == 200
-    assert  {'body': '', 'method': 'GET', 'params': {}, 'path': '/'} == data
+    assert {'body': '', 'method': 'GET', 'params': {}, 'path': '/'} == data
 
 
 def test_auth_is_set_correctly(event_loop):
@@ -33,10 +33,10 @@ def test_auth_is_set_correctly(event_loop):
 
 
 @mark.asyncio
-def test_request_is_properly_logged(connection, caplog, port, server):
+async def test_request_is_properly_logged(connection, caplog, port, server):
     server.register_response('/_cat/indices', {'cat': 'indices'})
-    yield from connection.perform_request('GET', '/_cat/indices', body=b'{}',
-                                          params={"format": "json"})
+    await connection.perform_request('GET', '/_cat/indices', body=b'{}',
+                                     params={"format": "json"})
 
     for logger, level, message in caplog.record_tuples:
         if logger == 'elasticsearch' and level == logging.INFO:
@@ -53,11 +53,10 @@ def test_request_is_properly_logged(connection, caplog, port, server):
 
 
 @mark.asyncio
-def test_error_is_properly_logged(connection, caplog, port, server):
+async def test_error_is_properly_logged(connection, caplog, port, server):
     server.register_response('/i', status=404)
     with raises(NotFoundError):
-        yield from connection.perform_request('GET', '/i',
-                                              params={'some': 'data'})
+        await connection.perform_request('GET', '/i', params={'some': 'data'})
 
     for logger, level, message in caplog.record_tuples:
         if logger == 'elasticsearch' and level == logging.WARNING:
@@ -69,16 +68,14 @@ def test_error_is_properly_logged(connection, caplog, port, server):
 
 
 @mark.asyncio
-def test_timeout_is_properly_raised(connection, server):
-    @asyncio.coroutine
-    def slow_request():
-        yield from asyncio.sleep(0.01)
+async def test_timeout_is_properly_raised(connection, server):
+    async def slow_request():
+        await asyncio.sleep(0.01)
         return {}
     server.register_response('/_search', slow_request())
 
     with raises(ConnectionTimeout):
-        yield from connection.perform_request('GET', '/_search',
-                                              timeout=0.0001)
+        await connection.perform_request('GET', '/_search', timeout=0.0001)
 
 
 def test_dns_cache_is_enabled_by_default(event_loop):

--- a/test_elasticsearch_async/test_connection_pool.py
+++ b/test_elasticsearch_async/test_connection_pool.py
@@ -1,0 +1,38 @@
+from pytest import mark
+from elasticsearch_async import AsyncElasticsearch
+from elasticsearch_async.connection_pool import \
+    AsyncConnectionPool, AsyncDummyConnectionPool
+
+
+@mark.asyncio
+def test_single_host_makes_async_dummy_pool(server, client, event_loop, port):
+    client = AsyncElasticsearch(port=port, loop=event_loop)
+    assert isinstance(client.transport.connection_pool, AsyncDummyConnectionPool)
+    yield from client.transport.close()
+
+
+@mark.asyncio
+def test_multiple_hosts_make_async_pool(server, event_loop, port):
+    client = AsyncElasticsearch(
+        hosts=['localhost', 'localhost'], port=port, loop=event_loop)
+    assert isinstance(client.transport.connection_pool, AsyncConnectionPool)
+    assert len(client.transport.connection_pool.orig_connections) == 2
+    yield from client.transport.close()
+
+
+@mark.asyncio
+def test_async_dummy_pool_is_closed_properly(server, event_loop, port):
+    client = AsyncElasticsearch(port=port, loop=event_loop)
+    assert isinstance(client.transport.connection_pool, AsyncDummyConnectionPool)
+    yield from client.transport.close()
+    assert client.transport.connection_pool.connection.session.closed
+
+
+@mark.asyncio
+def test_async_pool_is_closed_properly(server, event_loop, port):
+    client = AsyncElasticsearch(
+        hosts=['localhost', 'localhost'], port=port, loop=event_loop)
+    assert isinstance(client.transport.connection_pool, AsyncConnectionPool)
+    yield from client.transport.close()
+    for conn in client.transport.connection_pool.orig_connections:
+        assert conn.session.closed

--- a/test_elasticsearch_async/test_connection_pool.py
+++ b/test_elasticsearch_async/test_connection_pool.py
@@ -5,34 +5,34 @@ from elasticsearch_async.connection_pool import \
 
 
 @mark.asyncio
-def test_single_host_makes_async_dummy_pool(server, client, event_loop, port):
+async def test_single_host_makes_async_dummy_pool(server, client, event_loop, port):
     client = AsyncElasticsearch(port=port, loop=event_loop)
     assert isinstance(client.transport.connection_pool, AsyncDummyConnectionPool)
-    yield from client.transport.close()
+    await client.transport.close()
 
 
 @mark.asyncio
-def test_multiple_hosts_make_async_pool(server, event_loop, port):
+async def test_multiple_hosts_make_async_pool(server, event_loop, port):
     client = AsyncElasticsearch(
         hosts=['localhost', 'localhost'], port=port, loop=event_loop)
     assert isinstance(client.transport.connection_pool, AsyncConnectionPool)
     assert len(client.transport.connection_pool.orig_connections) == 2
-    yield from client.transport.close()
+    await client.transport.close()
 
 
 @mark.asyncio
-def test_async_dummy_pool_is_closed_properly(server, event_loop, port):
+async def test_async_dummy_pool_is_closed_properly(server, event_loop, port):
     client = AsyncElasticsearch(port=port, loop=event_loop)
     assert isinstance(client.transport.connection_pool, AsyncDummyConnectionPool)
-    yield from client.transport.close()
+    await client.transport.close()
     assert client.transport.connection_pool.connection.session.closed
 
 
 @mark.asyncio
-def test_async_pool_is_closed_properly(server, event_loop, port):
+async def test_async_pool_is_closed_properly(server, event_loop, port):
     client = AsyncElasticsearch(
         hosts=['localhost', 'localhost'], port=port, loop=event_loop)
     assert isinstance(client.transport.connection_pool, AsyncConnectionPool)
-    yield from client.transport.close()
+    await client.transport.close()
     for conn in client.transport.connection_pool.orig_connections:
         assert conn.session.closed

--- a/test_elasticsearch_async/test_transport.py
+++ b/test_elasticsearch_async/test_transport.py
@@ -1,14 +1,14 @@
-import asyncio
-
 from pytest import mark
 
 from elasticsearch_async import AsyncElasticsearch
+
 
 @mark.asyncio
 def test_sniff_on_start_sniffs(server, event_loop, port, sniff_data):
     server.register_response('/_nodes/_all/http', sniff_data)
 
-    client = AsyncElasticsearch(port=port, sniff_on_start=True, loop=event_loop)
+    client = AsyncElasticsearch(port=port, sniff_on_start=True,
+                                loop=event_loop)
 
     # sniff has been called in the background
     assert client.transport.sniffing_task is not None
@@ -19,12 +19,15 @@ def test_sniff_on_start_sniffs(server, event_loop, port, sniff_data):
 
     assert 1 == len(connections)
     assert 'http://node1:9200' == connections[0].host
-    client.transport.close()
+    yield from client.transport.close()
+
 
 @mark.asyncio
 def test_retry_will_work(port, server, event_loop):
-    client = AsyncElasticsearch(hosts=['not-an-es-host', 'localhost'], port=port, loop=event_loop, randomize_hosts=False)
+    client = AsyncElasticsearch(hosts=['not-an-es-host', 'localhost'],
+                                port=port, loop=event_loop,
+                                randomize_hosts=False)
 
     data = yield from client.info()
-    assert  {'body': '', 'method': 'GET', 'params': {}, 'path': '/'} == data
-    client.transport.close()
+    assert {'body': '', 'method': 'GET', 'params': {}, 'path': '/'} == data
+    yield from client.transport.close()

--- a/test_elasticsearch_async/test_transport.py
+++ b/test_elasticsearch_async/test_transport.py
@@ -1,10 +1,12 @@
+import asyncio
+
 from pytest import mark
 
 from elasticsearch_async import AsyncElasticsearch
 
 
 @mark.asyncio
-def test_sniff_on_start_sniffs(server, event_loop, port, sniff_data):
+async def test_sniff_on_start_sniffs(server, event_loop, port, sniff_data):
     server.register_response('/_nodes/_all/http', sniff_data)
 
     client = AsyncElasticsearch(port=port, sniff_on_start=True,
@@ -12,22 +14,22 @@ def test_sniff_on_start_sniffs(server, event_loop, port, sniff_data):
 
     # sniff has been called in the background
     assert client.transport.sniffing_task is not None
-    yield from client.transport.sniffing_task
+    await client.transport.sniffing_task
 
     assert [('GET', '/_nodes/_all/http', '', {})] == server.calls
     connections = client.transport.connection_pool.connections
 
     assert 1 == len(connections)
     assert 'http://node1:9200' == connections[0].host
-    yield from client.transport.close()
+    await client.transport.close()
 
 
 @mark.asyncio
-def test_retry_will_work(port, server, event_loop):
+async def test_retry_will_work(port, server, event_loop):
     client = AsyncElasticsearch(hosts=['not-an-es-host', 'localhost'],
                                 port=port, loop=event_loop,
                                 randomize_hosts=False)
 
-    data = yield from client.info()
+    data = await client.info()
     assert {'body': '', 'method': 'GET', 'params': {}, 'path': '/'} == data
-    yield from client.transport.close()
+    await client.transport.close()


### PR DESCRIPTION
Here is a backport of the commits made to the ES6 version of this library, but for people like us still stuck on ES 5. I forked from the 5.2.0 tag.

It contains all commits except the SSL context related stuff. In particular, it fixes the timeout context manager issue that is a blocker for users to upgrade to the latest version of aiohttp.

I've also shortened some lines to 80 chars to get it through our linting setup.