### PR TITLE
Apply fix 'async is a keyword on 3.7' for version 5.

### DIFF
--- a/elasticsearch_async/helpers.py
+++ b/elasticsearch_async/helpers.py
@@ -1,3 +1,4 @@
 import asyncio
 
-ensure_future = getattr(asyncio, 'ensure_future', asyncio.async)
+ensure_future = (getattr(asyncio, 'ensure_future', None) or
+                 getattr(asyncio, 'async', None))


### PR DESCRIPTION
This has previously been fixed for version 6 in #47.