### PR TITLE
Remove aiohttp warnings

### DIFF
--- a/elasticsearch_async/connection.py
+++ b/elasticsearch_async/connection.py
@@ -65,12 +65,12 @@ class AIOHttpConnection(Connection):
 
         self.session = aiohttp.ClientSession(
             auth=http_auth,
-            conn_timeout=self.timeout,
+            timeout=self.timeout,
             connector=aiohttp.TCPConnector(
                 loop=self.loop,
                 verify_ssl=verify_certs,
                 use_dns_cache=use_dns_cache,
-                ssl_context=ssl_context,
+                ssl=ssl_context,
             ),
             headers=headers
         )


### PR DESCRIPTION
In a project using `elasticsearch-py-async` version `6.2.0`, I see the following warning messages:
```
site-packages/elasticsearch_async/connection.py:73: DeprecationWarning: ssl_context is deprecated, use ssl=context instead
    ssl_context=ssl_context,
```
```
site-packages/elasticsearch_async/connection.py:75: DeprecationWarning: conn_timeout is deprecated, use timeout argument instead
    headers=headers
```
This PR makes this changes so the warning messages disappear and make the code functional with new versions.