### PR TITLE
Update the ClientSession to use the new timeout parameter.

### DIFF
--- a/elasticsearch_async/connection.py
+++ b/elasticsearch_async/connection.py
@@ -65,7 +65,7 @@ class AIOHttpConnection(Connection):
 
         self.session = aiohttp.ClientSession(
             auth=http_auth,
-            conn_timeout=self.timeout,
+            timeout=aiohttp.ClientTimeout(total=self.timeout),
             connector=aiohttp.TCPConnector(
                 loop=self.loop,
                 verify_ssl=verify_certs,


### PR DESCRIPTION
Previously only `conn_timeout` was being passed to `aiohttp.ClientSession`, meaning that any long or query would be interrupted after 5 minutes by the default total timeout of 5 minutes.

Additionally the connection timeout does not the original elasticsearch-py API, which specifies that the `timeout` parameter is the global timeout: https://elasticsearch-py.readthedocs.io/en/master/api.html#timeout

This PR updates the `ClientSession` instantiation to pass the `timeout` value to the global timeout.